### PR TITLE
Combined generic with Associated type magic with apathyboy's solution.

### DIFF
--- a/day01/src/main.rs
+++ b/day01/src/main.rs
@@ -4,21 +4,23 @@ use std::io::{BufRead, BufReader};
 
 use itertools::Itertools;
 
-fn part1(input: &HashSet<i32>) -> i32 {
+fn part1<T>(input: &HashSet<T>, goal: T) -> T
+  where T : Eq + std::hash::Hash + Copy + std::ops::Sub<Output=T> + std::ops::Mul<Output=T> {
     return input
         .iter()
-        .map(|a| (a, 2020 - a))
+        .map(|a| (*a, goal - *a))
         .filter(|(_, b)| input.contains(b))
         .map(|(a, b)| a * b)
         .next()
         .unwrap();
 }
 
-fn part2(input: &HashSet<i32>) -> i32 {
+fn part2<T>(input: &HashSet<T>, goal: T) -> T
+  where T : Eq + std::hash::Hash + Copy + std::ops::Sub<Output=T> + std::ops::Mul<Output=T> {
     return input
         .iter()
         .cartesian_product(input.iter())
-        .map(|(a, b)| (a, b, 2020 - *a - *b))
+        .map(|(a, b)| (*a, *b, goal - *a - *b))
         .filter(|(_, _, c)| input.contains(c))
         .map(|(a, b, c)| a * b * c)
         .next()
@@ -30,11 +32,11 @@ fn main() {
 
     let input: HashSet<i32> = BufReader::new(File::open("input/puzzle.txt").unwrap())
         .lines()
-        .map(|nr| nr.unwrap().parse::<i32>().unwrap())
+        .map(|nr| nr.unwrap().parse().unwrap())
         .collect();
 
-    println!("Part 1 Solution: {}", part1(&input));
-    println!("Part 2 Solution: {}", part2(&input));
+    println!("Part 1 Solution: {}", part1(&input, 2020));
+    println!("Part 2 Solution: {}", part2(&input, 2020));
 }
 
 #[cfg(test)]
@@ -53,7 +55,7 @@ mod tests {
             .map(|l| l.parse().unwrap())
             .collect();
 
-        assert_eq!(514579, part1(&input));
+        assert_eq!(514579, part1(&input, 2020));
     }
 
     #[test]
@@ -68,6 +70,6 @@ mod tests {
             .map(|l| l.parse().unwrap())
             .collect();
 
-        assert_eq!(241861950, part2(&input));
+        assert_eq!(241861950, part2(&input, 2020));
     }
 }


### PR DESCRIPTION
Hey Eric,

It's been a long time -- hope you're doing well. Feel free to reject this PR if you like; since I deleted my FB this is the best means I have to share some code with you which I thought you might appreciate. 

I recently started working on the AOC2020 puzzles to work on my Rust skills, and here's what I came up with:

    use std::collections::HashSet;

    use std::fs::File;
    use std::io::{self, BufRead};

    fn find_sum<T>(numbers: &HashSet<T>, goal: T) -> Option<(T, T)>
      where T : Eq + std::hash::Hash + Copy + std::ops::Sub<Output=T> {
        for num in numbers.iter() {
            if numbers.contains(&(goal-*num)) {
                return Some((*num, goal-*num));
            }
        }
        None
    }

    fn main() -> io::Result<()> {
        let mut numbers : HashSet<i32> = HashSet::new();

        // Load the input file into numbers.
        let file = File::open("input")?;
        for raw_line in io::BufReader::new(file).lines() {
            let line = raw_line?;
            match line.parse() {
                Ok(i)  => {
                    numbers.insert(i);
                },
                Err(_) => {
                    println!("Invalid line in input: {}.", line);
                }
            }
        }

        match find_sum(&numbers, 2020) {
            Some((a, b)) => { println!("{} + {} = 2020; {} * {} = {}", a, b, a, b, a * b); }
            None         => { }
        }

        for a in numbers.iter() {
            match find_sum(&numbers, 2020-a) {
                Some((b, c)) => { println!("{} + {} + {} = 2020; {} * {} * {} = {}", a, b, c, a, b, c, a * b * c); break }
                None         => { }
            }
        }

        return Ok(());

    }

I spent a long time trying to figure out how to constrain the generic type `T` to be `std::ops::Sub` but with an associated type `Output` that was of type `T`. A while of googling later, I found the magical syntax you see above. 

Once I got my solution working I decided to take a look at yours and see what we did different. I really liked the functional style of yours more than the mess of my own solution, but I noticed that yours wasn't as generic as mine. So I decided to combine them, and share the result with you in case you might find it interesting. I know you always enjoyed template-fu in C++, so I figured you might appreciate the magic syntax needed to get it working in Rust.

Anyway, this PR makes the `part1` and `part2` functions in your solution generic, so you could change it to `i64` in one place if you wanted. Not really useful, but a fun exercise nonetheless. 

Cheers,
Richard